### PR TITLE
Add misspelled variants of the image/jpeg mime type as found in the wild

### DIFF
--- a/BMECat.net/MimeTypes.cs
+++ b/BMECat.net/MimeTypes.cs
@@ -23,6 +23,8 @@ namespace BMECat.net
         private static Dictionary<string, MimeTypes> _mimeTypes = new Dictionary<string, MimeTypes>()
         {
             { "image/jpeg", MimeTypes.ImageJpeg },
+            { "image/jpg", MimeTypes.ImageJpeg },
+            { "images/jpg", MimeTypes.ImageJpeg },
             { "image/gif", MimeTypes.ImageGif },
             { "image/tif", MimeTypes.ImageTiff },
             { "image/tiff", MimeTypes.ImageTiff },


### PR DESCRIPTION
- Add `image/jpg` and `images/jpg` as variants for the `image/jpeg` mime type as found in a catalog of a large parts supplier